### PR TITLE
option to not cleanup the reprocessing directory

### DIFF
--- a/gen_dict_gen.py
+++ b/gen_dict_gen.py
@@ -43,6 +43,8 @@ def parse_args():
                         help='input directory, ex. /data/archive/sgp/sgpmetE13.00')
     parser.add_argument('-m', '--modify', dest='modify', type=int,
                         help='Column to modify and test.')
+    parser.add_argument('--no-cleanup', dest="no_clean", action="store_true",
+                        help="when true, does not cleanup datastream directory.")
     parser.add_argument('--create-dict', dest='create_dict', action="store_true")
     parser.add_argument('--delimiter', dest='delimiter', default=',', help='File delimiter.')
     parser.add_argument('--header', dest='header', type=int, default=0, help='Number of header lines.')
@@ -327,7 +329,8 @@ def main():
     # data_dictionary(dqr) # TODO This stuff
 
     # cleanup datastream direcotry
-    cleanup_datastream(dqr, site)
+    if not args.no_clean:
+        cleanup_datastream(dqr, site)
 
     # restage raw files from backup directory
     restage_files(args.input)


### PR DESCRIPTION
This option allows the user to not remove files and folders from the reprocessing datastream directory.